### PR TITLE
Dataloaders changes from quip doc, incorporated Corey's text changes

### DIFF
--- a/docs/python_docs/python/tutorials/getting-started/crash-course/5-datasets.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/5-datasets.md
@@ -16,7 +16,8 @@
 <!--- under the License. -->
 
 
-# Gluon `Dataset`s and `DataLoader`
+# Step 5: `Dataset`s and `DataLoader`
+-----------
 
 One of the most critical steps for model training and inference is loading the data: without data you can't do Machine Learning! In this tutorial you will use the Gluon API to define a [Dataset](/api/python/docs/api/gluon/data/index.html#datasets) and use a [DataLoader](/api/python/docs/api/gluon/data/index.html#dataloader) to iterate through the dataset in mini-batches.
 
@@ -26,14 +27,13 @@ import mxnet as mx
 import os
 import time
 import tarfile
-
 ```
 
 ## Introduction to `Dataset`s
-
+--------
 [Dataset](/api/python/docs/api/gluon/data/index.html#datasets) objects are used to represent collections of data, and include methods to load and parse the data (that is often stored on disk). Gluon has a number of different `Dataset` classes for working with image data straight out-of-the-box, but you'll use the [ArrayDataset](/api/python/docs/api/gluon/data/index.html#mxnet.gluon.data.ArrayDataset) to introduce the idea of a `Dataset`.
 
-You can start by generating random data `X` (with 3 variables) and corresponding random labels `y` to simulate a typical supervised learning task. You generate 10 samples and pass them all to the `ArrayDataset`.
+You will first start by generating random data `X` (with 3 variables) and corresponding random labels `y` to simulate a typical supervised learning task. You will generate 10 samples and pass them all to the `ArrayDataset`.
 
 
 
@@ -46,7 +46,7 @@ y = mx.random.uniform(shape=(10, 1))
 dataset = mx.gluon.data.dataset.ArrayDataset(X, y)
 ```
 
-A key feature of a `Dataset` is the __*ability to retrieve a single sample given an index*__. Your random data and labels were generated in memory, so this `ArrayDataset` doesn't have to load anything from disk, but the interface is the same for all `Dataset`'s.
+A key feature of a `Dataset` is the __*ability to retrieve a single sample given an index*__. Our random data and labels were generated in memory, so this `ArrayDataset` doesn't have to load anything from disk, but the interface is the same for all `Dataset`'s.
 
 
 
@@ -70,9 +70,10 @@ print(sample)
 
 
 
-You get a tuple of a data sample and its corresponding label, which makes sense because you passed the data `X` and the labels `y` in that order when we instantiated the `ArrayDataset`. We don't usually retrieve individual samples from `Dataset` objects though (unless we're quality checking the output samples). Instead we use a `DataLoader`.
+You get a tuple of a data sample and its corresponding label, which makes sense because you passed the data `X` and the labels `y` in that order when you instantiated the `ArrayDataset`. You don't usually retrieve individual samples from `Dataset` objects though (unless you're quality checking the output samples). Instead you use a `DataLoader`.
 
 ## Introduction to `DataLoader`
+----------
 
 A [DataLoader](/api/python/docs/api/gluon/data/index.html#dataloader) is used to create mini-batches of samples from a [Dataset](/api/python/docs/api/gluon/data/index.html#datasets), and provides a convenient iterator interface for looping these batches. It's typically much more efficient to pass a mini-batch of data through a neural network than a single sample at a time, because the computation can be performed in parallel. A required parameter of `DataLoader` is the size of the mini-batches you want to create, called `batch_size`.
 
@@ -96,15 +97,16 @@ for X_batch, y_batch in data_loader:
     X_batch has shape (5, 3), and y_batch has shape (5, 1)
 
 
-We can see 2 mini-batches of data (and labels), each with 5 samples, which makes sense given we started with a dataset of 10 samples. When comparing the shape of the batches to the samples returned by the `Dataset`, we've gained an extra dimension at the start which is sometimes called the batch axis.
+You can see 2 mini-batches of data (and labels), each with 5 samples, which makes sense given that you started with a dataset of 10 samples. When comparing the shape of the batches to the samples returned by the `Dataset`,you've gained an extra dimension at the start which is sometimes called the batch axis.
 
 Our `data_loader` loop will stop when every sample of `dataset` has been returned as part of a batch. Sometimes the dataset length isn't divisible by the mini-batch size, leaving a final batch with a smaller number of samples. `DataLoader`'s default behavior is to return this smaller mini-batch, but this can be changed by setting the `last_batch` parameter to `discard` (which ignores the last batch) or `rollover` (which starts the next epoch with the remaining samples).
 
 ## Machine learning with `Dataset`s and `DataLoader`s
+---------
 
 You will often use a few different `Dataset` objects in your Machine Learning project. It's essential to separate your training dataset from testing dataset, and it's also good practice to have validation dataset (a.k.a. development dataset) that can be used for optimising hyperparameters.
 
-Using Gluon `Dataset` objects, we define the data to be included in each of these separate datasets. Common use cases for loading data are covered already (e.g. [mxnet.gluon.data.vision.datasets.ImageFolderDataset](/api/python/docs/api/gluon/data/vision/index.html)), but it's simple to create your own custom `Dataset` classes for other types of data. You can even use included `Dataset` objects for common datasets if you want to experiment quickly; they download and parse the data for you! In this example we use the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset from Zalando Research.
+Using Gluon `Dataset` objects, you define the data to be included in each of these separate datasets. Common use cases for loading data are covered already (e.g. [mxnet.gluon.data.vision.datasets.ImageFolderDataset](/api/python/docs/api/gluon/data/vision/index.html)), but it's simple to create your own custom `Dataset` classes for other types of data. You can even use included `Dataset` objects for common datasets if you want to experiment quickly; they download and parse the data for you! In this example you use the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset from Zalando Research.
 
 Many of the image `Dataset`'s accept a function (via the optional `transform` parameter) which is applied to each sample returned by the `Dataset`. It's useful for performing data augmentation, but can also be used for more simple data type conversion and pixel value scaling as seen below.
 
@@ -117,8 +119,8 @@ def transform(data, label):
     data = data.astype('float32')/255
     return data, label
 
-train_dataset = mx.gluon.data.vision.datasets.FashionMNIST(train=True)#, transform=transform)
-valid_dataset = mx.gluon.data.vision.datasets.FashionMNIST(train=False)#, transform=transform)
+train_dataset = mx.gluon.data.vision.datasets.FashionMNIST(train=True, transform=transform)
+valid_dataset = mx.gluon.data.vision.datasets.FashionMNIST(train=False, transform=transform)
 ```
 
 
@@ -132,25 +134,18 @@ data = sample[0]
 label = sample[1]
 label_desc = {0:'T-shirt/top', 1:'Trouser', 2:'Pullover', 3:'Dress', 4:'Coat', 5:'Sandal', 6:'Shirt', 7:'Sneaker', 8:'Bag', 9:'Ankle boot'}
 
-imshow(data[:,:,0].asnumpy(), cmap='gray')
 print("Data type: {}".format(data.dtype))
 print("Label: {}".format(label))
 print("Label description: {}".format(label_desc[label]))
+imshow(data[:,:,0].asnumpy(), cmap='gray')
 ```
 
-    Data type: <class 'numpy.uint8'>
+    Data type: <class 'numpy.float32'>
     Label: 8
     Label description: Bag
 
 
-
-![png](output_10_1.png)
-
-
-
-```python
-# ![png](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/doc/tutorials/gluon/datasets/fashion_mnist_bag.png)
-```
+![png](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/doc/tutorials/gluon/datasets/fashion_mnist_bag.png)
 
 When training machine learning models it is important to shuffle the training samples every time you pass through the dataset (i.e. each epoch). Sometimes the order of your samples will have a spurious relationship with the target variable, and shuffling the samples helps remove this. With [DataLoader](/api/python/docs/api/gluon/data/index.html#dataloader) it's as simple as adding `shuffle=True`. You don't need to shuffle the validation and testing data though.
 
@@ -164,85 +159,13 @@ train_data_loader = mx.gluon.data.DataLoader(train_dataset, batch_size, shuffle=
 valid_data_loader = mx.gluon.data.DataLoader(valid_dataset, batch_size, num_workers=CPU_COUNT)
 ```
 
-With both `DataLoader`s defined, we can now train a model to classify each image and evaluate the validation loss at each epoch. Our Fashion MNIST dataset has 10 classes including shirt, dress, sneakers, etc. We define a simple fully connected network with a softmax output and use cross entropy as our loss.
-
-
-```python
-from mxnet import gluon, autograd, ndarray
-
-def construct_net():
-    net = gluon.nn.HybridSequential()
-    net.add(gluon.nn.Dense(128, activation="relu"))
-    net.add(gluon.nn.Dense(64, activation="relu"))
-    net.add(gluon.nn.Dense(10))
-    return net
-
-# construct and initialize network.
-ctx =  mx.gpu() if mx.context.num_gpus() else mx.cpu()
-
-net = construct_net()
-net.hybridize()
-net.initialize(mx.init.Xavier(), ctx=ctx)
-# define loss and trainer.
-criterion = gluon.loss.SoftmaxCrossEntropyLoss()
-trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.1})
-```
-
-
-```python
-
-            output = net(data.astype('float32'))
-    
-            loss = criterion(output, label)
-```
-
-
-```python
-epochs = 5
-for epoch in range(epochs):
-    # training loop (with autograd and trainer steps, etc.)
-    cumulative_train_loss = mx.nd.zeros(1, ctx=ctx)
-    training_samples = 0
-    for batch_idx, (data, label) in enumerate(train_data_loader):
-        data = data.as_in_context(ctx).reshape((-1, 784)) # 28*28=784
-        label = label.as_in_context(ctx)
-        with autograd.record():
-            output = net(data.astype('float32'))
-            loss = criterion(output, label)
-        loss.backward()
-        trainer.step(data.shape[0])
-        cumulative_train_loss += loss.sum()
-        training_samples += data.shape[0]
-    train_loss = cumulative_train_loss.asscalar()/training_samples
-
-    # validation loop
-    cumulative_valid_loss = mx.nd.zeros(1, ctx)
-    valid_samples = 0
-    for batch_idx, (data, label) in enumerate(valid_data_loader):
-        data = data.as_in_context(ctx).reshape((-1, 784)) # 28*28=784
-        label = label.as_in_context(ctx)
-        output = net(data.astype('float32'))
-        loss = criterion(output, label)
-        cumulative_valid_loss += loss.sum()
-        valid_samples += data.shape[0]
-    valid_loss = cumulative_valid_loss.asscalar()/valid_samples
-
-    print("Epoch {}, training loss: {:.2f}, validation loss: {:.2f}".format(epoch, train_loss, valid_loss))
-
-```
-
-    Epoch 0, training loss: 2.30, validation loss: 2.42
-    Epoch 1, training loss: 2.30, validation loss: 2.42
-    Epoch 2, training loss: 2.30, validation loss: 2.42
-    Epoch 3, training loss: 2.30, validation loss: 2.42
-    Epoch 4, training loss: 2.30, validation loss: 2.42
-
+With both `DataLoader`s defined, you can now train a model to classify each image and evaluate the validation loss at each epoch. See the next tutorial for how this is done.
 
 # Using own data with included `Dataset`s
-
+-------
 Gluon has a number of different [Dataset](https://mxnet.incubator.apache.org/api/python/gluon/data.html?highlight=dataset#mxnet.gluon.data.Dataset) classes for working with your own image data straight out-of-the-box. You can get started quickly using the [mxnet.gluon.data.vision.datasets.ImageFolderDataset](/api/python/docs/api/gluon/data/vision/datasets/index.html#mxnet.gluon.data.vision.datasets.ImageFolderDataset) which loads images directly from a user-defined folder, and infers the label (i.e. class) from the folders.
 
-We will run through an example for image classification, but a similar process applies for other vision tasks. If you already have your own collection of images to work with you should partition your data into training and test sets, and place all objects of the same class into seperate folders. Similar to:
+Here you will run through an example for image classification, but a similar process applies for other vision tasks. If you already have your own collection of images to work with you should partition your data into training and test sets, and place all objects of the same class into seperate folders. Similar to:
 ```
     ./images/train/car/abc.jpg
     ./images/train/car/efg.jpg
@@ -271,18 +194,14 @@ if not os.path.isfile(archive_path):
     print('Data extracted.')
 ```
 
-    Extracting 101_ObjectCategories.tar.gz in data...
-    Data extracted.
-
-
-After downloading and extracting the data archive, we have two folders: `data/101_ObjectCategories` and `data/101_ObjectCategories_test`. We load the data into separate training and testing  [ImageFolderDataset](/api/python/docs/api/gluon/data/vision/datasets/index.html#mxnet.gluon.data.vision.datasets.ImageFolderDataset)s.
+After downloading and extracting the data archive, you have two folders: `data/101_ObjectCategories` and `data/101_ObjectCategories_test`. You can then load the data into separate training and testing  [ImageFolderDataset](/api/python/docs/api/gluon/data/vision/datasets/index.html#mxnet.gluon.data.vision.datasets.ImageFolderDataset)s.
 
 training_path = os.path.join(data_folder, dataset_name)
 testing_path = os.path.join(data_folder, "{}_test".format(dataset_name))
 
-We instantiate the [ImageFolderDataset](https://mxnet.incubator.apache.org/api/python/gluon/data.html?highlight=imagefolderdataset#mxnet.gluon.data.vision.datasets.ImageFolderDataset)s by providing the path to the data, and the folder structure will be traversed to determine which image classes are available and which images correspond to each class. You must take care to ensure the same classes are both the training and testing datasets, otherwise the label encodings can get muddled.
+You instantiate the [ImageFolderDataset](https://mxnet.incubator.apache.org/api/python/gluon/data.html?highlight=imagefolderdataset#mxnet.gluon.data.vision.datasets.ImageFolderDataset)s by providing the path to the data, and the folder structure will be traversed to determine which image classes are available and which images correspond to each class. You must take care to ensure the same classes are both the training and testing datasets, otherwise the label encodings can get muddled.
 
-Optionally, you can pass a `transform` parameter to these `Dataset`'s as we've seen before.
+Optionally, you can pass a `transform` parameter to these `Dataset`'s as you've seen before.
 
 
 ```python
@@ -320,11 +239,12 @@ sample = train_dataset[sample_idx]
 data = sample[0]
 label = sample[1]
 
-imshow(data.asnumpy(), cmap='gray')
 print("Data type: {}".format(data.dtype))
 print("Label: {}".format(label))
 print("Label description: {}".format(train_dataset.synsets[label]))
 assert label == 1
+
+imshow(data.asnumpy(), cmap='gray')
 ```
 
     Data type: <class 'numpy.uint8'>
@@ -332,23 +252,16 @@ assert label == 1
     Label description: Faces_easy
 
 
-
-![png](output_27_1.png)
-
-
-
-```python
-# ![png](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/doc/tutorials/gluon/datasets/caltech101_face.png)<!--notebook-skip-line-->
-```
+![png](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/doc/tutorials/gluon/datasets/caltech101_face.png)<!--notebook-skip-line-->
 
 # Using your own data with custom `Dataset`s
-
+------
 Sometimes you have data that doesn't quite fit the format expected by the included [Dataset](/api/python/docs/api/gluon/data/index.html#mxnet.gluon.data.Dataset)s. You might be able to preprocess your data to fit the expected format, but it is easy to create your own dataset to do this.
 
 All you need to do is create a class that implements a `__getitem__` method, that returns a sample (i.e. a tuple of [mx.nd.NDArray](/api/python/docs/api/ndarray/ndarray.html#mxnet.ndarray.NDArray)'s).
 
 # New in MXNet 2.0: faster C++ backend dataloaders
-
+------
 As part of an effort to speed up the current data loading pipeline using gluon dataset and dataloader, a new dataloader was created that uses only a C++ backend and avoids potentially slow calls to Python functions.
 
 See [original issue](https://github.com/apache/incubator-mxnet/issues/17269), [pull request](https://github.com/apache/incubator-mxnet/pull/17464) and [implementation](https://github.com/apache/incubator-mxnet/pull/17841).
@@ -376,7 +289,7 @@ This new dataloader provides:
 
 Users can continue to with the traditional gluon.data.Dataloader and the C++ backend will be applied automatically. The 'try_nopython' default is 'Auto', which detects whether the C++ backend is available given the dataset and transforms. 
 
-Here we show a performance increase on a t3.2xl instance for the CIFAR10 dataset with the C++ backend.
+Here you will show a performance increase on a t3.2xl instance for the CIFAR10 dataset with the C++ backend.
 
 ### Using the C++ backend:
 
@@ -427,9 +340,8 @@ print('Elapsed time for python dataloader:', time.time() - start)
 
 
 ### The C++ backend loader was almost 3X faster for this particular use case
-This improvement in performance will not be seen in all cases, but when possible we encourage users to compare the dataloader throughput for these two options.
+This improvement in performance will not be seen in all cases, but when possible you are encouraged to compare the dataloader throughput for these two options.
 
-
-```python
-# <!-- INSERT SOURCE DOWNLOAD BUTTONS -->
-```
+## Next Steps
+-----
+Now that you have some experience with MXNet's datasets and dataloaders, it's time to use them for [Step 6: Training a Neural Network](https://github.com/vidyaravipati/incubator-mxnet/blob/mxnet2.0_crashcourse/docs/python_docs/python/tutorials/getting-started/crash-course/6-trainNN.md).


### PR DESCRIPTION
## Description ##
Dataloaders tutorial, changes from the quip doc and Corey's text changes.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
